### PR TITLE
 Fix Failing Test: SDG management relations_spec

### DIFF
--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -79,6 +79,13 @@ module CommonActions
     end
   end
 
+  def click_sdg_goal_or_target_with_autocomplete(code)
+    fill_in "Goals and Targets", with: code
+    within(".amsify-list") do
+      find("[data-val='#{code}']").click
+    end
+  end
+
   def remove_sdg_goal_or_target_tag(code)
     within "span[data-val='#{code}']" do
       click_button "Remove"

--- a/spec/system/sdg_management/relations_spec.rb
+++ b/spec/system/sdg_management/relations_spec.rb
@@ -297,7 +297,9 @@ describe "SDG Relations" do
 
       visit sdg_management_edit_legislation_process_path(process)
 
-      find(:css, ".sdg-related-list-selector-input").set("1.2, 2, 1.1.1, ")
+      click_sdg_goal(2)
+      click_sdg_goal_or_target_with_autocomplete(1.2)
+      click_sdg_goal_or_target_with_autocomplete("1.1.1")
 
       click_button "Update Process"
 
@@ -339,7 +341,8 @@ describe "SDG Relations" do
       debate = create(:sdg_review, relatable: create(:debate, title: "SDG debate")).relatable
 
       visit sdg_management_edit_debate_path(debate, filter: "sdg_reviewed")
-      find(:css, ".sdg-related-list-selector-input").set("1.2, 2.1,")
+      click_sdg_goal_or_target_with_autocomplete(1.2)
+      click_sdg_goal_or_target_with_autocomplete(2.1)
       click_button "Update Debate"
 
       expect(page).not_to have_content "Debate updated successfully and marked as reviewed"

--- a/spec/system/sdg_management/relations_spec.rb
+++ b/spec/system/sdg_management/relations_spec.rb
@@ -360,18 +360,15 @@ describe "SDG Relations" do
       create(:sdg_local_target, code: "1.1.1")
       visit sdg_management_edit_legislation_process_path(process)
 
-      fill_in "Goals and Targets", with: "3"
-      within(".amsify-list") { find(:css, "[data-val='3']").click }
+      click_sdg_goal_or_target_with_autocomplete(3)
 
       within(".amsify-suggestags-input-area") { expect(page).to have_content "SDG3" }
 
-      fill_in "Goals and Targets", with: "1.1"
-      within(".amsify-list") { find(:css, "[data-val='1.1']").click }
+      click_sdg_goal_or_target_with_autocomplete(1.1)
 
       within(".amsify-suggestags-input-area") { expect(page).to have_content "1.1" }
 
-      fill_in "Goals and Targets", with: "1.1.1"
-      within(".amsify-list") { find(:css, "[data-val='1.1.1']").click }
+      click_sdg_goal_or_target_with_autocomplete("1.1.1")
 
       within(".amsify-suggestags-input-area") { expect(page).to have_content "1.1.1" }
 


### PR DESCRIPTION
## References
When cloning or forking the latest consul, installing it locally, there are two failing scenarios when running the tests. 
spec/system/sdg_management/relations_spec.rb
- "allows adding the goals, global targets and local targets and marks the resource as reviewed"
- "does not show the review notice when resource was already reviewed"
![Screenshot from 2023-06-10 14-25-48](https://github.com/Meet-Democracy/consul-original/assets/114252883/66513fc4-f5aa-404f-9b03-a92ff1279ee6)

When looking at the screenshots of the tests we see that the data is not being updated
![failures_r_spec_example_groups_sdg_relations_edit_allows_adding_the_goals__global_targets_and_local_targets_and_marks_the_resource_as_reviewed_71](https://github.com/Meet-Democracy/consul-original/assets/114252883/afb5615f-7140-4393-b67d-e0b327f67469)

Expected Result:
All tests should pass without any failures.

Actual Result:
Two scenarios related to SDG goal/target management are failing.

## Objectives

This pull request aims to address and resolve 2 failing test scenarios related to SDG goal/target management. 
The proposed changes in this pull request aim to rectify the issues causing the test failure and improve code reusability.

Modifications Made:

1. Created a reusable function, click_sdg_goal_or_target_with_autocomplete, to add an SDG goal or target with autocomplete functionality. This function accepts a code parameter and simulates the interaction of filling in the "Goals and Targets" field and selecting the desired SDG goal or target using the already existing working code on the same test 

```
def click_sdg_goal_or_target_with_autocomplete(code)
   fill_in "Goals and Targets", with: code
   within(".amsify-list") do
       find("[data-val='#{code}']").click
    end
 end
```
  
2. . Fixed the non-working find(:css, ".sdg-related-list-selector-input").set("1.2, 2.1,") line with the newly created click_sdg_goal_or_target_with_autocomplete function. This modification ensures that the SDG goals or targets with codes are correctly selected.

3. . Replaced repetitive code blocks with calls to the click_sdg_goal_or_target_with_autocomplete function for improved code readability and future use.
![Screenshot from 2023-06-10 14-38-33](https://github.com/Meet-Democracy/consul-original/assets/114252883/54c4cf0a-e02b-4e54-8bd0-e7514653f647)

