### PR TITLE
Render markdown tables in legislation draft

### DIFF
--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -9,6 +9,7 @@
 // 07. Legislation comments
 // 08. Legislation draft comment
 // 09. Legislation proposals
+// 10. Legislation draft tables
 //
 
 // 01. Hero
@@ -499,34 +500,6 @@
           }
         }
       }
-      
-      table {
-        @extend .scroll;
-        border: $table-border;
-        border-collapse: collapse;
-        color: $body-font-color;
-        background-color: $table-background;
-
-        th {
-          background: $table-head-background;
-          color: $table-head-font-color
-        }
-
-        tr {
-
-          td {
-            line-height: $line-height;
-          }
-
-          &:nth-child(odd) {
-            background: $table-background;
-          }
-
-          &:nth-child(even) {
-            background: $table-striped-background;
-          }
-        }
-      }
     }
 
     .calc-comments {
@@ -1012,5 +985,38 @@
     margin-left: 50%;
     margin-top: $line-height;
     transform: translateX(-50%);
+  }
+}
+
+// 10. Legislation draft table
+// -------------------------
+
+.draft.text {
+  table {
+    @extend .scroll;
+    border: $table-border;
+    border-collapse: collapse;
+    color: $body-font-color;
+    background-color: $table-background;
+
+    th {
+      background: $table-head-background;
+      color: $table-head-font-color
+    }
+
+    tr {
+
+      td {
+        line-height: $line-height;
+      }
+
+      &:nth-child(odd) {
+        background: $table-background;
+      }
+
+      &:nth-child(even) {
+        background: $table-striped-background;
+      }
+    }
   }
 }

--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -499,6 +499,34 @@
           }
         }
       }
+      
+      table {
+        @extend .scroll;
+        border: $table-border;
+        border-collapse: collapse;
+        color: $body-font-color;
+        background-color: $table-background;
+
+        th {
+          background: $table-head-background;
+          color: $table-head-font-color
+        }
+
+        tr {
+
+          td {
+            line-height: $line-height;
+          }
+
+          &:nth-child(odd) {
+            background: $table-background;
+          }
+
+          &:nth-child(even) {
+            background: $table-striped-background;
+          }
+        }
+      }
     }
 
     .calc-comments {

--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -991,9 +991,11 @@
 // 10. Legislation draft table
 // -------------------------
 
-.draft.text {
+.draft-text {
   table {
-    @extend .scroll;
+    display: block;
+    width: 100%;
+    overflow-x: auto;
     border: $table-border;
     border-collapse: collapse;
     color: $body-font-color;
@@ -1001,7 +1003,7 @@
 
     th {
       background: $table-head-background;
-      color: $table-head-font-color
+      color: $table-head-font-color;
     }
 
     tr {

--- a/app/models/legislation/draft_version.rb
+++ b/app/models/legislation/draft_version.rb
@@ -22,9 +22,17 @@ class Legislation::DraftVersion < ApplicationRecord
   scope :published, -> { where(status: "published").order("id DESC") }
 
   def body_html
-    renderer = Redcarpet::Render::HTML.new(with_toc_data: true)
+    # See https://github.com/vmg/redcarpet for options
+    render_options = {
+      with_toc_data: true
+    }
+    renderer = Redcarpet::Render::HTML.new(render_options)
+    extensions = {
+      tables: true
+    }
+    renderer = Redcarpet::Render::HTML.new(render_options)
 
-    Redcarpet::Markdown.new(renderer).render(body)
+    Redcarpet::Markdown.new(renderer, extensions).render(body)
   end
 
   def toc_html

--- a/app/models/legislation/draft_version.rb
+++ b/app/models/legislation/draft_version.rb
@@ -30,7 +30,6 @@ class Legislation::DraftVersion < ApplicationRecord
     extensions = {
       tables: true
     }
-    renderer = Redcarpet::Render::HTML.new(render_options)
 
     Redcarpet::Markdown.new(renderer, extensions).render(body)
   end

--- a/lib/admin_legislation_sanitizer.rb
+++ b/lib/admin_legislation_sanitizer.rb
@@ -1,6 +1,6 @@
 class AdminLegislationSanitizer < WYSIWYGSanitizer
   def allowed_tags
-    super + %w[img h1 h4 h5 h6]
+    super + %w[img h1 h4 h5 h6 table thead tbody tr th td]
   end
 
   def allowed_attributes

--- a/spec/factories/legislations.rb
+++ b/spec/factories/legislations.rb
@@ -127,6 +127,15 @@ FactoryBot.define do
     trait :final_version do
       final_version { true }
     end
+
+    trait :with_table do
+      body { <<~BODY_MARKDOWN }
+      | id | name    | age | gender |
+      |----|---------|-----|--------|
+      | 1  | Roberta | 39  | M      |
+      | 2  | Oliver  | 25  | F      |
+      BODY_MARKDOWN
+    end
   end
 
   factory :legislation_annotation, class: "Legislation::Annotation" do

--- a/spec/factories/legislations.rb
+++ b/spec/factories/legislations.rb
@@ -130,11 +130,11 @@ FactoryBot.define do
 
     trait :with_table do
       body { <<~BODY_MARKDOWN }
-      | id | name    | age | gender |
-      |----|---------|-----|--------|
-      | 1  | Roberta | 39  | M      |
-      | 2  | Oliver  | 25  | F      |
-      BODY_MARKDOWN
+        | id | name    | age | gender |
+        |----|---------|-----|--------|
+        | 1  | Roberta | 39  | M      |
+        | 2  | Oliver  | 25  | F      |
+        BODY_MARKDOWN
     end
   end
 

--- a/spec/lib/admin_legislation_sanitizer_spec.rb
+++ b/spec/lib/admin_legislation_sanitizer_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+describe AdminLegislationSanitizer do
+  let(:sanitizer) { AdminLegislationSanitizer.new }
+
+  describe "#sanitize" do
+    it "allows images" do
+      html = 'Dangerous<img src="/smile.png" alt="Smile"> image'
+      expect(sanitizer.sanitize(html)).to eq(html)
+    end
+
+    it "allows h1 to h6" do
+      html = '<h1>Heading 1</h1>
+              <h2>Heading 2</h2>
+              <h3>Heading 3</h3>
+              <h4>Heading 4</h4>
+              <h5>Heading 5</h5>
+              <h6>Heading 6</h6>'            
+      expect(sanitizer.sanitize(html)).to eq(html)
+    end
+
+    it "allows tables" do
+      html = '<table>
+                <thead>
+                  <tr>
+                    <th>id</th>
+                    <th>name</th>
+                    <th>age</th>
+                    <th>gender</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>1</td>
+                    <td>Roberta</td>
+                    <td>39</td>
+                    <td>M</td>
+                  </tr>
+                  <tr>
+                    <td>2</td>
+                    <td>Oliver</td>
+                    <td>25</td>
+                    <td>F</td>
+                  </tr>
+                </tbody>
+              </table>'
+      expect(sanitizer.sanitize(html)).to eq(html)
+    end
+
+    it "allows alt src and id" do
+      html = 'Dangerous<img src="/smile.png" alt="Smile" id="smile"> image'
+      expect(sanitizer.sanitize(html)).to eq(html)
+    end
+
+    it "doesn't allow style" do
+      html = 'Dangerous<img src="/smile.png" alt="Smile" style="width:10px;"> image'
+      expect(sanitizer.sanitize(html)).not_to eq(html)
+    end
+
+    it "doesn't allow class" do
+      html = 'Dangerous<img src="/smile.png" alt="Smile" class="smile"> image'
+      expect(sanitizer.sanitize(html)).not_to eq(html)
+    end
+  end
+end

--- a/spec/lib/admin_legislation_sanitizer_spec.rb
+++ b/spec/lib/admin_legislation_sanitizer_spec.rb
@@ -15,7 +15,7 @@ describe AdminLegislationSanitizer do
               <h3>Heading 3</h3>
               <h4>Heading 4</h4>
               <h5>Heading 5</h5>
-              <h6>Heading 6</h6>'            
+              <h6>Heading 6</h6>'
       expect(sanitizer.sanitize(html)).to eq(html)
     end
 

--- a/spec/models/legislation/draft_version_spec.rb
+++ b/spec/models/legislation/draft_version_spec.rb
@@ -81,7 +81,7 @@ describe Legislation::DraftVersion do
       | id | name    | age | gender |
       |----|---------|-----|--------|
       | 1  | Roberta | 39  | M      |
-      | 2  | Oliver  | 25  | F      |      
+      | 2  | Oliver  | 25  | F      |
     BODY_MARKDOWN
   end
 

--- a/spec/models/legislation/draft_version_spec.rb
+++ b/spec/models/legislation/draft_version_spec.rb
@@ -29,6 +29,15 @@ describe Legislation::DraftVersion do
     expect(legislation_draft_version.toc_html).to eq(toc_html)
   end
 
+  it "renders the tables from the markdown body field" do
+    legislation_draft_version.body = body_with_table_markdown
+
+    legislation_draft_version.save!
+
+    expect(legislation_draft_version.body_html).to eq(body_with_table_html)
+    expect(legislation_draft_version.toc_html).to eq(toc_html)
+  end
+
   def body_markdown
     <<~BODY_MARKDOWN
       # Title 1
@@ -47,6 +56,32 @@ describe Legislation::DraftVersion do
       # Title 2
 
       Something about this.
+    BODY_MARKDOWN
+  end
+
+  def body_with_table_markdown
+    <<~BODY_MARKDOWN
+      # Title 1
+
+      Some paragraph.
+
+      A list:
+
+      - item 1
+      - item 2
+
+      ## Subtitle
+
+      Another paragraph.
+
+      # Title 2
+
+      Something about this.
+
+      | id | name    | age | gender |
+      |----|---------|-----|--------|
+      | 1  | Roberta | 39  | M      |
+      | 2  | Oliver  | 25  | F      |      
     BODY_MARKDOWN
   end
 
@@ -70,6 +105,51 @@ describe Legislation::DraftVersion do
       <h1 id="title-2">Title 2</h1>
 
       <p>Something about this.</p>
+    BODY_HTML
+  end
+
+  def body_with_table_html
+    <<~BODY_HTML
+      <h1 id="title-1">Title 1</h1>
+
+      <p>Some paragraph.</p>
+
+      <p>A list:</p>
+
+      <ul>
+      <li>item 1</li>
+      <li>item 2</li>
+      </ul>
+
+      <h2 id="subtitle">Subtitle</h2>
+
+      <p>Another paragraph.</p>
+
+      <h1 id="title-2">Title 2</h1>
+
+      <p>Something about this.</p>
+
+      <table><thead>
+      <tr>
+      <th>id</th>
+      <th>name</th>
+      <th>age</th>
+      <th>gender</th>
+      </tr>
+      </thead><tbody>
+      <tr>
+      <td>1</td>
+      <td>Roberta</td>
+      <td>39</td>
+      <td>M</td>
+      </tr>
+      <tr>
+      <td>2</td>
+      <td>Oliver</td>
+      <td>25</td>
+      <td>F</td>
+      </tr>
+      </tbody></table>
     BODY_HTML
   end
 

--- a/spec/system/legislation/draft_versions_spec.rb
+++ b/spec/system/legislation/draft_versions_spec.rb
@@ -403,13 +403,13 @@ describe "Legislation Draft Versions" do
 
     scenario "See table on default screen" do
       visit legislation_process_draft_version_path(draft_version.process, draft_version)
-      
+
       expect(page).to have_css("table")
       expect(page).to have_content "Roberta"
       expect(page).to have_content "25"
     end
 
-    scenario "See table on small screen" , :small_window do
+    scenario "See table on small screen", :small_window do
       visit legislation_process_draft_version_path(draft_version.process, draft_version)
 
       expect(page).to have_css("table")

--- a/spec/system/legislation/draft_versions_spec.rb
+++ b/spec/system/legislation/draft_versions_spec.rb
@@ -397,4 +397,24 @@ describe "Legislation Draft Versions" do
       expect(page).to have_content "my other annotation"
     end
   end
+
+  context "See table from markdown" do
+    let(:draft_version) { create(:legislation_draft_version, :published, :with_table) }
+
+    scenario "See table on default screen" do
+      visit legislation_process_draft_version_path(draft_version.process, draft_version)
+      
+      expect(page).to have_css("table")
+      expect(page).to have_content "Roberta"
+      expect(page).to have_content "25"
+    end
+
+    scenario "See table on small screen" , :small_window do
+      visit legislation_process_draft_version_path(draft_version.process, draft_version)
+
+      expect(page).to have_css("table")
+      expect(page).to have_content "Roberta"
+      expect(page).to have_content "25"
+    end
+  end
 end

--- a/spec/system/legislation/draft_versions_spec.rb
+++ b/spec/system/legislation/draft_versions_spec.rb
@@ -400,8 +400,11 @@ describe "Legislation Draft Versions" do
 
   context "See table from markdown" do
     let(:draft_version) { create(:legislation_draft_version, :published, :with_table) }
+    let(:path) do
+      edit_admin_legislation_process_draft_version_path(draft_version.process, draft_version)
+    end
 
-    scenario "See table on default screen" do
+    scenario "See table as a user" do
       visit legislation_process_draft_version_path(draft_version.process, draft_version)
 
       expect(page).to have_css("table")
@@ -409,8 +412,11 @@ describe "Legislation Draft Versions" do
       expect(page).to have_content "25"
     end
 
-    scenario "See table on small screen", :small_window do
-      visit legislation_process_draft_version_path(draft_version.process, draft_version)
+    scenario "See table as an admin" do
+      login_as(administrator)
+
+      visit path
+      click_link class: "fullscreen-toggle"
 
       expect(page).to have_css("table")
       expect(page).to have_content "Roberta"


### PR DESCRIPTION
## Objectives

This pull request aims at fixing the display of tables in the Legislation Draft from as a user, it also add test in order to make sure that the tables are rendered.

1- Allow table tags in Admin Legislation Sanitizer
2- Add Tables option to Redcarpet in Legislation draft
3- Add custom CSS for Table inside Legislation draft using global table variables. we also make the table responsive with scrolling
4- Add Test to render markdown tables in Legislation drafts as a user and as an admin
5- Add Test for Admin Legislation Sanitizer. We also strengthen allowed and not allowed parameters 

## Visual Changes

![Screenshot from 2023-06-21 10-27-01](https://github.com/Meet-Democracy/consul-original/assets/114252883/e1c905c6-5c31-4c22-97ae-6fd4a2ad71a0)

## Notes
- See [Redcarpet](https://github.com/vmg/redcarpet) for more options
- We used render_options and extensions variable in order to align with the existing code at app/helpers/application_helper.rb
